### PR TITLE
Add docker compose configuration and BERT image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# BERT model to download
+BERT_MODEL=bert-base-uncased
+
+# Database connection strings
+DATABASE_URL_OPENWEBUI=
+DATABASE_URL_LANGFUSE=
+
+# Langfuse authentication
+NEXTAUTH_URL=
+NEXTAUTH_SECRET=
+
+# SearXNG configuration
+SEARXNG_BASE_URL=
+
+# LlamaIndex API key
+LLAMAINDEX_API_KEY=
+
+# Neo4j authentication
+NEO4J_AUTH=neo4j/test

--- a/Dockerfile.bert
+++ b/Dockerfile.bert
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir transformers==4.36.2
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Dabotman Containers
+
+This repository includes a `docker-compose.yml` with several services used in the project. A sample `.env.example` file is provided to configure environment variables for the containers.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in the required values.
+
+```bash
+cp .env.example .env
+# edit .env
+```
+
+2. Build the BERT image and start the services with docker compose.
+
+```bash
+docker compose build bert
+docker compose up -d
+```
+
+The services will be available on the following ports by default:
+
+- **OpenWebUI** – <http://localhost:3000>
+- **Langfuse** – <http://localhost:3001>
+- **SearXNG** – <http://localhost:3002>
+- **LlamaIndex** – <http://localhost:3003>
+- **Neo4j** – bolt on `7687` and web on `7474`
+- **Portainer** – <https://localhost:9443>
+
+## BERT Container
+
+`Dockerfile.bert` builds a minimal image with the Hugging Face `transformers` library. The `entrypoint.sh` script downloads the model specified by the `BERT_MODEL` environment variable when the container starts.
+
+You can run it alone using:
+
+```bash
+docker compose run bert
+```
+
+The downloaded model files are stored in the `bert-models` volume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,95 @@
+version: '3.8'
+
+volumes:
+  bert-models:
+  openwebui-data:
+  langfuse-data:
+  searxng-data:
+  llamaindex-data:
+  neo4j-data:
+  portainer-data:
+
+networks:
+  dabotman-net:
+    driver: bridge
+
+services:
+  bert:
+    build:
+      context: .
+      dockerfile: Dockerfile.bert
+    volumes:
+      - bert-models:/models
+    environment:
+      - BERT_MODEL=${BERT_MODEL}
+    networks:
+      - dabotman-net
+
+  openwebui:
+    image: ghcr.io/open-webui/open-webui:latest
+    environment:
+      - DATABASE_URL=${DATABASE_URL_OPENWEBUI}
+    volumes:
+      - openwebui-data:/data
+    ports:
+      - "3000:8080"
+    networks:
+      - dabotman-net
+
+  langfuse:
+    image: langfuse/langfuse:latest
+    environment:
+      - DATABASE_URL=${DATABASE_URL_LANGFUSE}
+      - NEXTAUTH_URL=${NEXTAUTH_URL}
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+    volumes:
+      - langfuse-data:/var/lib/langfuse
+    ports:
+      - "3001:3000"
+    networks:
+      - dabotman-net
+
+  searxng:
+    image: searxng/searxng:latest
+    environment:
+      - BASE_URL=${SEARXNG_BASE_URL}
+    volumes:
+      - searxng-data:/etc/searxng
+    ports:
+      - "3002:8080"
+    networks:
+      - dabotman-net
+
+  llamaindex:
+    image: llamaindex/llamaindex:latest
+    environment:
+      - LLAMAINDEX_API_KEY=${LLAMAINDEX_API_KEY}
+    volumes:
+      - llamaindex-data:/data
+    ports:
+      - "3003:8080"
+    networks:
+      - dabotman-net
+
+  neo4j:
+    image: neo4j:5
+    volumes:
+      - neo4j-data:/data
+    environment:
+      - NEO4J_AUTH=${NEO4J_AUTH}
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    networks:
+      - dabotman-net
+
+  portainer:
+    image: portainer/portainer-ce:latest
+    volumes:
+      - portainer-data:/data
+    ports:
+      - "9443:9443"
+    restart: unless-stopped
+    networks:
+      - dabotman-net
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+MODEL="${BERT_MODEL:-bert-base-uncased}"
+python - <<PY
+from transformers import AutoModel, AutoTokenizer
+import os
+model_name = os.environ.get('BERT_MODEL', 'bert-base-uncased')
+AutoModel.from_pretrained(model_name)
+AutoTokenizer.from_pretrained(model_name)
+print(f"Downloaded {model_name}")
+PY
+exec "$@"


### PR DESCRIPTION
## Summary
- add docker compose stack with BERT, OpenWebUI, Langfuse, SearXNG, LlamaIndex, Neo4j and Portainer services
- add Dockerfile.bert and entrypoint script to download a BERT model
- provide `.env.example` for all environment variables
- document setup and usage in README

## Testing
- `git status --short`