### PR TITLE
Add supabase and additional services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# BERT model to download
+BERT_MODEL=bert-base-uncased
+
+# Database connection strings
+DATABASE_URL_OPENWEBUI=
+DATABASE_URL_LANGFUSE=
+
+# Langfuse authentication
+NEXTAUTH_URL=
+NEXTAUTH_SECRET=
+
+# SearXNG configuration
+SEARXNG_BASE_URL=
+
+# LlamaIndex API key
+LLAMAINDEX_API_KEY=
+
+# Neo4j authentication
+NEO4J_AUTH=neo4j/test
+
+# Supabase settings
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+
+# TigerGraph credentials
+TIGERGRAPH_USER=
+TIGERGRAPH_PASS=
+
+# Docling configuration
+DOCLING_API_KEY=

--- a/Dockerfile.bert
+++ b/Dockerfile.bert
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir transformers==4.36.2
+
+ARG BERT_MODEL=bert-base-uncased
+ENV BERT_MODEL=$BERT_MODEL
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Dabotman Containers
+
+This repository includes a `docker-compose.yml` with several services used in the project. A sample `.env.example` file is provided to configure values that may be needed by the individual containers.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in the required values.
+
+```bash
+cp .env.example .env
+# edit .env
+```
+
+2. Build the BERT images and start the services with docker compose.
+
+```bash
+docker compose build bert-base bert-large
+docker compose up -d
+```
+
+The services will be available on the following ports by default:
+
+- **OpenWebUI** – <http://localhost:3000>
+- **Langfuse** – <http://localhost:3001>
+- **SearXNG** – <http://localhost:3002>
+- **LlamaIndex** – <http://localhost:3003>
+- **Neo4j** – bolt on `7687` and web on `7474`
+- **Portainer** – <https://localhost:9443>
+- **Supabase** – <http://localhost:5432>
+- **TigerGraph** – REST on `9000` and UI on `14240`
+- **Docling** – <http://localhost:8501>
+
+## BERT Container
+
+`Dockerfile.bert` builds a minimal image with the Hugging Face `transformers` library. Each BERT service is built with a different model using build arguments so no runtime environment variables are required. The `entrypoint.sh` script downloads the model on start.
+
+You can run it alone using:
+
+```bash
+docker compose run bert-base
+```
+
+The downloaded model files are stored in the `bert-models` volume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,125 @@
+version: '3.8'
+
+volumes:
+  bert-models:
+  openwebui-data:
+  langfuse-data:
+  searxng-data:
+  llamaindex-data:
+  neo4j-data:
+  portainer-data:
+  supabase-data:
+  tigergraph-data:
+  docling-data:
+
+networks:
+  dabotman-net:
+    driver: bridge
+
+services:
+  bert-base:
+    build:
+      context: .
+      dockerfile: Dockerfile.bert
+      args:
+        BERT_MODEL: bert-base-uncased
+    volumes:
+      - bert-models:/models
+    networks:
+      - dabotman-net
+
+  bert-large:
+    build:
+      context: .
+      dockerfile: Dockerfile.bert
+      args:
+        BERT_MODEL: bert-large-uncased
+    volumes:
+      - bert-models:/models
+    networks:
+      - dabotman-net
+
+  openwebui:
+    image: ghcr.io/open-webui/open-webui:latest
+    volumes:
+      - openwebui-data:/data
+    ports:
+      - "3000:8080"
+    networks:
+      - dabotman-net
+
+  langfuse:
+    image: langfuse/langfuse:latest
+    volumes:
+      - langfuse-data:/var/lib/langfuse
+    ports:
+      - "3001:3000"
+    networks:
+      - dabotman-net
+
+  searxng:
+    image: searxng/searxng:latest
+    volumes:
+      - searxng-data:/etc/searxng
+    ports:
+      - "3002:8080"
+    networks:
+      - dabotman-net
+
+  llamaindex:
+    image: llamaindex/llamaindex:latest
+    volumes:
+      - llamaindex-data:/data
+    ports:
+      - "3003:8080"
+    networks:
+      - dabotman-net
+
+  neo4j:
+    image: neo4j:5
+    volumes:
+      - neo4j-data:/data
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    networks:
+      - dabotman-net
+
+  portainer:
+    image: portainer/portainer-ce:latest
+    volumes:
+      - portainer-data:/data
+    ports:
+      - "9443:9443"
+    restart: unless-stopped
+    networks:
+      - dabotman-net
+
+  supabase:
+    image: supabase/postgres:latest
+    volumes:
+      - supabase-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - dabotman-net
+
+  tigergraph:
+    image: tigergraph/tigergraph:latest
+    volumes:
+      - tigergraph-data:/data
+    ports:
+      - "14240:14240"
+      - "9000:9000"
+    networks:
+      - dabotman-net
+
+  docling:
+    image: docling/docling:latest
+    volumes:
+      - docling-data:/data
+    ports:
+      - "8501:8501"
+    networks:
+      - dabotman-net
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+MODEL="${BERT_MODEL:-bert-base-uncased}"
+python - <<PY
+from transformers import AutoModel, AutoTokenizer
+import os
+model_name = os.environ.get('BERT_MODEL', 'bert-base-uncased')
+AutoModel.from_pretrained(model_name)
+AutoTokenizer.from_pretrained(model_name)
+print(f"Downloaded {model_name}")
+PY
+exec "$@"


### PR DESCRIPTION
## Summary
- split BERT models into multiple containers using build args
- remove all environment sections from docker compose
- add supabase, tigergraph and docling services
- provide extra environment placeholders
- document updated stack and usage

## Testing
- `git status --short`
